### PR TITLE
Fix: remove hardcoded 1800s from Replication model

### DIFF
--- a/src/models/Replication.js
+++ b/src/models/Replication.js
@@ -21,8 +21,7 @@ const ReplicationSchema = new Schema(
     },
     duration: {
       type: Number,
-      required: true,
-      default: 1800,
+      default: null,
     },
     isRepeatable: {
       type: Boolean,

--- a/src/services/v1/ReplicationService.js
+++ b/src/services/v1/ReplicationService.js
@@ -101,6 +101,10 @@ class ReplicationService {
     return await ReplicationRepository.update(id, { form: null });
   }
 
+  async deleteDuration(id) {
+    return await ReplicationRepository.update(id, { duration: null });
+  }
+
   async toggleAskSolution(id, leiaId) {
     const leia = await ReplicationRepository.findLeia(id, leiaId);
     if (!leia) {


### PR DESCRIPTION
Removed default timer length to account for timer being optional.