### PR TITLE
Add draft save endpoint for editor

### DIFF
--- a/src/controllers/v1/interactionController.js
+++ b/src/controllers/v1/interactionController.js
@@ -5,6 +5,7 @@ import {
   sendSessionMessageValidator,
   saveResultAndFinishSessionValidator,
   startTestSessionValidator,
+  saveDraftValidator,
 } from '../../validators/v1/interactionValidator.js';
 
 export const startSession = async (req, res, next) => {
@@ -64,6 +65,17 @@ export const finishSession = async (req, res, next) => {
   try {
     const { sessionId } = req.params;
     const session = await InteractionService.finishSession(sessionId);
+    res.json(session);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const saveDraft = async (req, res, next) => {
+  try {
+    const value = await saveDraftValidator.validateAsync(req.body);
+    const { sessionId } = req.params;
+    const session = await InteractionService.saveDraft(sessionId, value.draft);
     res.json(session);
   } catch (error) {
     next(error);

--- a/src/models/Session.js
+++ b/src/models/Session.js
@@ -45,6 +45,9 @@ const sessionSchema = new Schema(
       type: Boolean,
       default: false,
     },
+    draft: {
+      type: String,
+    },
   },
   {
     strict: false,

--- a/src/routes/v1/interactionRoutes.js
+++ b/src/routes/v1/interactionRoutes.js
@@ -8,6 +8,7 @@ import {
   startTestSession,
   getSolution,
   finishSession,
+  saveDraft,
 } from '../../controllers/v1/interactionController.js';
 import { authContext } from '../../middlewares/auth.js';
 
@@ -19,6 +20,7 @@ router.post('/test', authContext, startTestSession);
 router.post('/:sessionId/messages', sendSessionMessage);
 router.post('/:sessionId/result', saveResultAndFinishSession);
 router.post('/:sessionId/finish', finishSession);
+router.post('/:sessionId/draft', saveDraft);
 
 // GET
 router.get('/:sessionId', getSessionData);

--- a/src/services/v1/InteractionService.js
+++ b/src/services/v1/InteractionService.js
@@ -279,6 +279,21 @@ class InteractionService {
     };
   }
 
+  async saveDraft(sessionId, draft) {
+    const session = await SessionService.findById(sessionId);
+    if (!session) {
+      const error = new Error('Session not found');
+      error.statusCode = 404;
+      throw error;
+    }
+    if (session.finishedAt) {
+      const error = new Error('Session already finished');
+      error.statusCode = 403;
+      throw error;
+    }
+    return await SessionService.saveDraft(session.id, draft);
+  }
+
   async getEvaluation(sessionId) {
     let session = await SessionService.findById(sessionId);
     if (!session) {

--- a/src/services/v1/SessionService.js
+++ b/src/services/v1/SessionService.js
@@ -109,6 +109,10 @@ class SessionService {
   async updateIsRunnerInitialized(id, isRunnerInitialized) {
     return await SessionRepository.update(id, { isRunnerInitialized });
   }
+
+  async saveDraft(id, draft) {
+    return await SessionRepository.update(id, { draft });
+  }
 }
 
 export default new SessionService();

--- a/src/validators/v1/interactionValidator.js
+++ b/src/validators/v1/interactionValidator.js
@@ -17,3 +17,7 @@ export const sendSessionMessageValidator = Joi.object({
 export const saveResultAndFinishSessionValidator = Joi.object({
   result: Joi.string().required(),
 });
+
+export const saveDraftValidator = Joi.object({
+  draft: Joi.string().allow('').required(),
+});


### PR DESCRIPTION
 Adds a POST /api/v1/interactions/:sessionId/draft endpoint that saves the current editor content to the session without finishing it. Adds a draft field to the Session model and wires up the validator, service, and controller following existing patterns. 