### PR TITLE
Read widgets from Problem (dual-read) + per-tool usage/disable + merge develop (BYOK)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,4 @@
 services:
-  mongodb-workbench:
-    restart: unless-stopped
-    image: mongo:latest
-    container_name: mongodb-workbench
-    environment:
-      - MONGO_INITDB_ROOT_USERNAME=${MONGO_USERNAME}
-      - MONGO_INITDB_ROOT_PASSWORD=${MONGO_PASSWORD}
-    ports:
-      - '${MONGO_PORT}:27017'
-    volumes:
-      - mongo-workbench:/data/db
   workbench-backend:
     restart: unless-stopped
     build:
@@ -17,7 +6,7 @@ services:
       dockerfile: Dockerfile
     container_name: workbench-backend
     environment:
-      - MONGO_URI=mongodb://${MONGO_USERNAME}:${MONGO_PASSWORD}@mongodb-workbench:27017/workbench?authSource=admin
+      - MONGO_URI=${MONGO_URI}
       - FRONTEND_URL=${FRONTEND_URL}
       - RUNNER_URL=${RUNNER_URL}
       - RUNNER_KEY=${RUNNER_KEY}
@@ -26,10 +15,8 @@ services:
       - NODE_ENV=${NODE_ENV}
       - PORT=80
       - ADMIN_SECRET=${ADMIN_SECRET}
-    depends_on:
-      - mongodb-workbench
+      - JWT_SECRET=${JWT_SECRET}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - GEMINI_API_KEY=${GEMINI_API_KEY}
     ports:
       - '${PORT}:80'
-
-volumes:
-  mongo-workbench:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@leia-org/luke-server": "^0.2.0",
+        "@leia-org/luke-server": "^0.2.1",
         "axios": "^1.7.9",
         "bcryptjs": "^3.0.2",
         "cors": "^2.8.5",
@@ -892,9 +892,9 @@
       "license": "MIT"
     },
     "node_modules/@leia-org/luke-server": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@leia-org/luke-server/-/luke-server-0.2.0.tgz",
-      "integrity": "sha512-Uq+y9L0s8U+DDg8V9+F9tGv007gd0rkl1vuMVL4XtOmwtr75CsVG+xe6Ib7v2hIb3n1KzY/9vKXBE95Mpsqn7Q==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@leia-org/luke-server/-/luke-server-0.2.1.tgz",
+      "integrity": "sha512-auRDa7QSJZRLpOpgfDLQfw6qnpBBiJu27y6r0JEP2tPdq0P9lt/oyz97eaB3KYyzylQWHOm+A/u2N7GgkKullA==",
       "license": "MIT",
       "dependencies": {
         "jsonwebtoken": "^9.0.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/leia-org/workbench-back-v2#readme",
   "description": "",
   "dependencies": {
-    "@leia-org/luke-server": "^0.2.0",
+    "@leia-org/luke-server": "^0.2.1",
     "axios": "^1.7.9",
     "bcryptjs": "^3.0.2",
     "cors": "^2.8.5",

--- a/src/controllers/v1/interactionController.js
+++ b/src/controllers/v1/interactionController.js
@@ -43,8 +43,19 @@ export const sendSessionMessage = async (req, res, next) => {
   try {
     const value = await sendSessionMessageValidator.validateAsync(req.body);
     const { sessionId } = req.params;
-    const message = await InteractionService.sendSessionMessage(sessionId, value.message);
-    res.json({ message });
+    const result = await InteractionService.sendSessionMessage(sessionId, value.message, {
+      tools: value.tools,
+      toolResults: value.toolResults,
+    });
+    // Runner may return either a final text message or a batch of tool
+    // calls that the frontend has to execute. We forward whichever shape
+    // came back; the frontend distinguishes by the presence of toolCalls.
+    if (result && Array.isArray(result.toolCalls) && result.toolCalls.length > 0) {
+      res.json({ toolCalls: result.toolCalls });
+    } else {
+      const message = typeof result === 'string' ? result : result?.message;
+      res.json({ message });
+    }
   } catch (error) {
     next(error);
   }

--- a/src/services/v1/InteractionService.js
+++ b/src/services/v1/InteractionService.js
@@ -132,16 +132,28 @@ class InteractionService {
     delete leia.leia.spec.behaviour.spec.description;
     delete leia.leia.spec.behaviour.spec.role;
 
-    // Extract audioMode and lukeConfig for frontend but keep runnerConfiguration private
+    // Extract audioMode, lukeConfig and the runner provider for the
+    // frontend; everything else in runnerConfiguration stays private.
     const audioMode = leia.runnerConfiguration?.audioMode || null;
     const lukeConfig = leia.runnerConfiguration?.lukeConfig || null;
+    const runnerProvider = leia.runnerConfiguration?.provider || null;
     const hideAudioTranscription = leia.runnerConfiguration?.hideAudioTranscription || null;
     delete leia.runnerConfiguration;
     delete leia.sessionCount;
 
-    // Add audioMode and lukeConfig back for frontend consumption
+    // Decide whether the session is tool-capable. Widgets are only
+    // useful when the active path supports function calls:
+    //   - audioMode === 'luke': luke-server handles tools (Gemini Live
+    //     and OpenAI Realtime both support function declarations).
+    //   - text mode: only the `openai-responses` runner provider wires
+    //     tools to the model. Other providers (gemini text, ollama)
+    //     ignore them, so we don't show the widget panel for those.
+    const isToolCapable =
+      audioMode === 'luke' ||
+      (audioMode == null && runnerProvider === 'openai-responses');
+
     leia.audioMode = audioMode;
-    if (audioMode === 'luke' && lukeConfig) {
+    if (lukeConfig && (audioMode === 'luke' || (isToolCapable && Array.isArray(lukeConfig.widgets) && lukeConfig.widgets.length > 0))) {
       leia.lukeConfig = lukeConfig;
     }
     leia.hideAudioTranscription = hideAudioTranscription;
@@ -188,7 +200,7 @@ class InteractionService {
     return { solution, solutionFormat };
   }
 
-  async sendSessionMessage(sessionId, message) {
+  async sendSessionMessage(sessionId, message, options = {}) {
     let session = await SessionService.findById(sessionId);
     if (!session) {
       const error = new Error('Session not found');
@@ -210,15 +222,32 @@ class InteractionService {
       throw error;
     }
 
-    const newUserMessage = await MessageService.create(message, false, session.id);
-    session = await SessionService.addMessage(session.id, newUserMessage.id);
+    const { tools, toolResults } = options;
+    const isToolContinuation = Array.isArray(toolResults) && toolResults.length > 0;
 
-    const leiaMessage = await RunnerService.sendMessage(session.id, message);
+    // Only persist the user message on the first turn of a tool round-trip.
+    // Continuations (toolResults) keep the same logical user turn going.
+    if (!isToolContinuation && typeof message === 'string' && message.length > 0) {
+      const newUserMessage = await MessageService.create(message, false, session.id);
+      session = await SessionService.addMessage(session.id, newUserMessage.id);
+    }
 
-    const newLeiaMessage = await MessageService.create(leiaMessage, true, session.id);
-    session = await SessionService.addMessage(session.id, newLeiaMessage.id);
+    const runnerResponse = await RunnerService.sendMessage(session.id, message, { tools, toolResults });
 
-    return leiaMessage;
+    // Runner returns either { message } or { toolCalls } (or a raw string
+    // for older code paths). Only persist a Leia message when we got a
+    // final text response back.
+    if (runnerResponse && Array.isArray(runnerResponse.toolCalls) && runnerResponse.toolCalls.length > 0) {
+      return { toolCalls: runnerResponse.toolCalls };
+    }
+
+    const leiaMessage = typeof runnerResponse === 'string' ? runnerResponse : runnerResponse?.message;
+    if (leiaMessage) {
+      const newLeiaMessage = await MessageService.create(leiaMessage, true, session.id);
+      session = await SessionService.addMessage(session.id, newLeiaMessage.id);
+    }
+
+    return { message: leiaMessage };
   }
 
   async saveResultAndFinishSession(sessionId, result) {

--- a/src/services/v1/InteractionService.js
+++ b/src/services/v1/InteractionService.js
@@ -7,6 +7,46 @@ import SpectatorService from './SpectatorService.js';
 import logger from '../../utils/logger.js';
 import mongoose from 'mongoose';
 
+// Applies the problem's per-tool authoring to the tool schemas the client
+// sends to the runner: drops tools the instructor disabled and appends their
+// activity-specific usage guidance to each tool's description. The tool's
+// schema/parameters are never authored in the problem — only referenced by
+// name — so this only ever touches `description` and membership.
+//
+// Returns the tools unchanged when the problem declares no widgets/tools, so
+// activities without tool functions are unaffected.
+function applyProblemToolConfig(tools, leia) {
+  if (!Array.isArray(tools) || tools.length === 0) return tools;
+
+  const widgets = leia?.leia?.spec?.problem?.spec?.widgets;
+  if (!Array.isArray(widgets) || widgets.length === 0) return tools;
+
+  // name -> { enabled, usage } across all of the problem's widgets.
+  const config = new Map();
+  for (const widget of widgets) {
+    if (!Array.isArray(widget?.tools)) continue;
+    for (const tool of widget.tools) {
+      if (tool && typeof tool.name === 'string') config.set(tool.name, tool);
+    }
+  }
+  if (config.size === 0) return tools;
+
+  const out = [];
+  for (const tool of tools) {
+    const cfg = config.get(tool?.name);
+    if (cfg && cfg.enabled === false) continue; // instructor disabled this tool
+    if (cfg && typeof cfg.usage === 'string' && cfg.usage.trim()) {
+      out.push({
+        ...tool,
+        description: `${(tool.description || '').trim()}\n\nActivity guidance: ${cfg.usage.trim()}`.trim(),
+      });
+    } else {
+      out.push(tool);
+    }
+  }
+  return out;
+}
+
 class InteractionService {
   async startSession(userEmail, replicationCode) {
     logger.info(`User ${userEmail} is trying to join replication ${replicationCode}`);
@@ -135,9 +175,19 @@ class InteractionService {
     // Extract audioMode, lukeConfig and the runner provider for the
     // frontend; everything else in runnerConfiguration stays private.
     const audioMode = leia.runnerConfiguration?.audioMode || null;
-    const lukeConfig = leia.runnerConfiguration?.lukeConfig || null;
+    const runnerLukeConfig = leia.runnerConfiguration?.lukeConfig || null;
     const runnerProvider = leia.runnerConfiguration?.provider || null;
     const hideAudioTranscription = leia.runnerConfiguration?.hideAudioTranscription || null;
+
+    // Widgets now live in the problem definition (authored in the designer)
+    // and ride here inside leia.leia.spec.problem.spec.widgets. Fall back to
+    // the legacy runnerConfiguration.lukeConfig.widgets for LEIAs configured
+    // before the migration (dual-read).
+    const problemWidgets = leia.leia?.spec?.problem?.spec?.widgets;
+    const widgets = Array.isArray(problemWidgets) && problemWidgets.length > 0
+      ? problemWidgets
+      : (Array.isArray(runnerLukeConfig?.widgets) ? runnerLukeConfig.widgets : []);
+
     delete leia.runnerConfiguration;
     delete leia.sessionCount;
 
@@ -153,8 +203,11 @@ class InteractionService {
       (audioMode == null && runnerProvider === 'openai-responses');
 
     leia.audioMode = audioMode;
-    if (lukeConfig && (audioMode === 'luke' || (isToolCapable && Array.isArray(lukeConfig.widgets) && lukeConfig.widgets.length > 0))) {
-      leia.lukeConfig = lukeConfig;
+    // Expose the widgets (+ luke provider/voice when present) to the FE under
+    // `lukeConfig` — the shape Chat.tsx already consumes — whenever the active
+    // mode can actually use them. The mode itself stays a workbench concern.
+    if (audioMode === 'luke' || (isToolCapable && widgets.length > 0)) {
+      leia.lukeConfig = { ...(runnerLukeConfig || {}), widgets };
     }
     leia.hideAudioTranscription = hideAudioTranscription;
 
@@ -232,7 +285,11 @@ class InteractionService {
       session = await SessionService.addMessage(session.id, newUserMessage.id);
     }
 
-    const runnerResponse = await RunnerService.sendMessage(session.id, message, { tools, toolResults });
+    // Layer the problem's per-tool authoring (disable / usage guidance) onto
+    // the tool schemas the client sends. No-op when the problem declares no
+    // widgets/tools, so plain text activities are unaffected.
+    const effectiveTools = applyProblemToolConfig(tools, leia);
+    const runnerResponse = await RunnerService.sendMessage(session.id, message, { tools: effectiveTools, toolResults });
 
     // Runner returns either { message } or { toolCalls } (or a raw string
     // for older code paths). Only persist a Leia message when we got a

--- a/src/services/v1/LukeService.js
+++ b/src/services/v1/LukeService.js
@@ -190,9 +190,15 @@ function buildInstructions(leia) {
     }
   });
 
-  const widgets = leia.runnerConfiguration?.lukeConfig?.widgets || [];
+  // Widgets now come from the problem definition (authored in the designer)
+  // and ride inside leia.leia.spec.problem.spec.widgets. Fall back to the
+  // legacy runnerConfiguration.lukeConfig.widgets for pre-migration LEIAs.
+  const problemWidgets = leia.leia?.spec?.problem?.spec?.widgets;
+  const widgets = Array.isArray(problemWidgets) && problemWidgets.length > 0
+    ? problemWidgets
+    : (leia.runnerConfiguration?.lukeConfig?.widgets || []);
   const widgetHints = widgets
-    .map((w) => describeWidget(w.widgetType, w.slot))
+    .map((w) => describeWidget(w.widgetType, w.slot, w.tools))
     .filter(Boolean);
   if (widgetHints.length > 0) {
     instructionParts.push('\n=== AVAILABLE TOOLS (voice-mode widgets) ===');
@@ -205,9 +211,36 @@ function buildInstructions(leia) {
   return instructionParts.filter((part) => part.trim() !== '').join('\n');
 }
 
+// Builds the voice-mode hint for a widget: the static catalog description
+// plus any activity-specific tool guidance authored in the problem.
+function describeWidget(widgetType, slot, toolsConfig) {
+  const base = baseWidgetDescription(widgetType, slot);
+  if (!base) return null;
+  const guidance = buildToolGuidance(toolsConfig);
+  return guidance ? `${base}\n${guidance}` : base;
+}
+
+// Per-tool guidance authored by the instructor in the problem definition:
+// when to use a tool, or that a tool is disabled for this activity. The tool
+// schemas themselves are fixed by the platform and not authored here.
+function buildToolGuidance(toolsConfig) {
+  if (!Array.isArray(toolsConfig) || toolsConfig.length === 0) return '';
+  const lines = [];
+  for (const tool of toolsConfig) {
+    if (!tool || typeof tool.name !== 'string') continue;
+    if (tool.enabled === false) {
+      lines.push(`    * Do NOT use ${tool.name} in this activity.`);
+    } else if (typeof tool.usage === 'string' && tool.usage.trim()) {
+      lines.push(`    * ${tool.name}: ${tool.usage.trim()}`);
+    }
+  }
+  if (lines.length === 0) return '';
+  return ['    Activity-specific guidance:', ...lines].join('\n');
+}
+
 // Static catalog mirror for the few widgets the workbench renders in
 // voice mode. Must be kept in sync with leia-workbench-frontend/src/widgets/catalog.ts.
-function describeWidget(widgetType, slot) {
+function baseWidgetDescription(widgetType, slot) {
   switch (widgetType) {
     case 'codeEditor':
       return [

--- a/src/services/v1/RunnerService.js
+++ b/src/services/v1/RunnerService.js
@@ -18,19 +18,24 @@ class RunnerService {
     return response.data.sessionId;
   }
 
-  async sendMessage(sessionId, message) {
+  async sendMessage(sessionId, message, options = {}) {
+    const body = {};
+    if (typeof message === 'string' && message.length > 0) body.message = message;
+    if (Array.isArray(options.tools) && options.tools.length > 0) body.tools = options.tools;
+    if (Array.isArray(options.toolResults) && options.toolResults.length > 0) body.toolResults = options.toolResults;
+
     const response = await axios.post(
       `${process.env.RUNNER_URL}/api/v1/leias/${sessionId}/messages`,
-      {
-        message,
-      },
+      body,
       {
         headers: {
           Authorization: 'Bearer ' + process.env.RUNNER_KEY,
         },
       }
     );
-    return response.data.message;
+    // Forward the full response shape upward so the caller can branch on
+    // toolCalls vs. final text.
+    return response.data;
   }
 
   async getEvaluationAndScore(sessionId, result) {

--- a/src/validators/v1/interactionValidator.js
+++ b/src/validators/v1/interactionValidator.js
@@ -10,9 +10,25 @@ export const startTestSessionValidator = Joi.object({
   leiaId: Joi.string().hex().length(24).required(),
 });
 
+// `message` and `toolResults` are mutually-required (one or the other):
+//   - first turn from the user: { message, tools? }
+//   - continuation after a tool round-trip: { toolResults, tools? }
 export const sendSessionMessageValidator = Joi.object({
-  message: Joi.string().required(),
-});
+  message: Joi.string(),
+  tools: Joi.array().items(
+    Joi.object({
+      name: Joi.string().required(),
+      description: Joi.string().allow('').default(''),
+      parameters: Joi.object().unknown(true).default({}),
+    }).unknown(true)
+  ),
+  toolResults: Joi.array().items(
+    Joi.object({
+      callId: Joi.string().required(),
+      output: Joi.any().required(),
+    })
+  ),
+}).or('message', 'toolResults');
 
 export const saveResultAndFinishSessionValidator = Joi.object({
   result: Joi.string().required(),

--- a/src/validators/v1/replicationValidator.js
+++ b/src/validators/v1/replicationValidator.js
@@ -30,11 +30,15 @@ export const updateReplicationLeiaRunnerConfigurationValidator = Joi.object({
     otherwise: Joi.valid(null).optional().default(null),
   }),
   lukeConfig: Joi.object({
-    provider: Joi.string().valid('openai', 'gemini').required(),
-    voice: Joi.string().required(),
-    // Per-LEIA voice-mode widgets. The workbench-frontend catalog maps
-    // widgetType → React component. Slot constrains where it renders
-    // inside the voice UI.
+    // provider/voice are only meaningful when audioMode === 'luke'. The
+    // same lukeConfig bucket is reused by text mode (which only needs
+    // `widgets`), so both fields are optional at the schema level — the
+    // luke flow validates their presence at runtime when audio kicks in.
+    provider: Joi.string().valid('openai', 'gemini').optional(),
+    voice: Joi.string().optional(),
+    // Per-LEIA widgets / tool functions. The workbench-frontend catalog
+    // maps widgetType → React component; the runner uses the presence of
+    // a non-empty `widgets` array to gate tool-functions on the LLM.
     widgets: Joi.array()
       .items(
         Joi.object({

--- a/src/validators/v1/replicationValidator.js
+++ b/src/validators/v1/replicationValidator.js
@@ -36,9 +36,11 @@ export const updateReplicationLeiaRunnerConfigurationValidator = Joi.object({
     // luke flow validates their presence at runtime when audio kicks in.
     provider: Joi.string().valid('openai', 'gemini').optional(),
     voice: Joi.string().optional(),
-    // Per-LEIA widgets / tool functions. The workbench-frontend catalog
-    // maps widgetType → React component; the runner uses the presence of
-    // a non-empty `widgets` array to gate tool-functions on the LLM.
+    // Legacy: widgets / tool functions are now authored per activity in the
+    // problem definition (Designer) and read from leia.spec.problem.spec.widgets
+    // at runtime. This field is kept (optional) only so pre-migration
+    // replications that still carry widgets here validate on save; the
+    // workbench no longer authors it.
     widgets: Joi.array()
       .items(
         Joi.object({


### PR DESCRIPTION
## What

- `InteractionService.getSessionData` sources widgets from the problem (`leia.spec.problem.spec.widgets`) with fallback to legacy `runnerConfiguration.lukeConfig.widgets`, exposed to the FE under `lukeConfig.widgets` (unchanged FE contract).
- `sendSessionMessage` enriches the tools sent to the runner with the problem's per-tool `usage` guidance and drops `enabled:false` tools. No-op when the activity has no widgets.
- `LukeService` (voice) reads widgets from the problem and injects per-tool usage/disable guidance into the system instructions.

## Merge of `develop`

Clean auto-merge with BYOK / manage-apiKeys (JWT auth, `ProviderService`, model→provider resolution stored in `runnerConfiguration.provider`, activate/test validations). Verified the resolved provider module is exactly what the tool gate reads, so text-mode tools still work with BYOK.

## Verification

`eslint` clean; `node --check` OK.