### PR TITLE
fix(live): socket auth rejects admins on /replications/:id/live after auth migration

### DIFF
--- a/src/socket/index.js
+++ b/src/socket/index.js
@@ -2,6 +2,7 @@ import { Server } from 'socket.io';
 import logger from '../utils/logger.js';
 import SpectatorService from '../services/v1/SpectatorService.js';
 import ReplicationService from '../services/v1/ReplicationService.js';
+import { verifyToken } from '../utils/jwt.js';
 
 let io = null;
 
@@ -35,6 +36,23 @@ export function initializeSocket(httpServer) {
         };
       } catch (error) {
         throw new Error(error.message || 'Invalid authentication token');
+      }
+    }
+
+    // User JWT issued by the auth service — the frontend sends it as auth.token.
+    // An admin gets full dashboard/spectate access; this replaces the legacy
+    // adminSecret after the auth migration. Falls through to share-token
+    // handling if it isn't a valid user JWT.
+    const potentialUserJwt =
+      typeof auth.token === 'string' && auth.token.split('.').length === 3 ? auth.token : null;
+    if (potentialUserJwt) {
+      try {
+        const decoded = verifyToken(potentialUserJwt);
+        if (decoded?.role === 'admin') {
+          return { isAdmin: true, userId: decoded.id, role: decoded.role };
+        }
+      } catch {
+        // Not a valid user JWT — fall through to share-token handling below.
       }
     }
 


### PR DESCRIPTION
## Bug

Opening `/replications/:id/live` (the live dashboard) as an admin shows **"Access denied"**.

## Cause

The auth migration moved the frontend to JWT (`useAuth`). For the live dashboard WebSocket, the frontend now sends the **user JWT** in the handshake as `auth.token` (`LiveDashboard.tsx`: `if (token && isAdmin) authPayload.token = token`). But the Socket.IO auth middleware (`src/socket/index.js` → `buildAuthContext`) was never updated for this: it only understands `auth.adminSecret` (no longer sent), a **spectate** token in `auth.jwt`, or a **share token**. So the admin's user JWT falls into the `auth.shareToken || auth.token` branch and is treated as a share token → `ReplicationService.checkAccess(replicationId, isAdmin=false, shareToken=<JWT>)` → **Access denied**.

## Fix

`buildAuthContext` now verifies `auth.token` as a **user JWT** (`verifyToken` / `JWT_SECRET`, the same util the HTTP middleware uses). If it's valid and `role === 'admin'`, the socket grants `{ isAdmin: true }` (full dashboard/spectate access, replacing the legacy adminSecret). Non-JWT / invalid tokens fall through to the existing share-token handling, so spectator and share-link flows are unchanged.

## Notes / scope

- Matches the frontend, which only sends the user JWT for `role === 'admin'`. `advanced` users accessing the live view (and per-owner scoping) would need a separate follow-up (frontend gating + `checkAccess` by owner); not in this fix.
- `node --check` + `eslint` clean. Runtime check needs the live stack (Socket.IO); the change mirrors the HTTP JWT-auth path.