### PR TITLE
feat: background supervisor LLM

### DIFF
--- a/src/controllers/v1/interactionController.js
+++ b/src/controllers/v1/interactionController.js
@@ -50,11 +50,12 @@ export const sendSessionMessage = async (req, res, next) => {
     // Runner may return either a final text message or a batch of tool
     // calls that the frontend has to execute. We forward whichever shape
     // came back; the frontend distinguishes by the presence of toolCalls.
+    const nudge = result && typeof result === 'object' && result.nudge ? result.nudge : undefined;
     if (result && Array.isArray(result.toolCalls) && result.toolCalls.length > 0) {
-      res.json({ toolCalls: result.toolCalls });
+      res.json({ toolCalls: result.toolCalls, ...(nudge ? { nudge } : {}) });
     } else {
       const message = typeof result === 'string' ? result : result?.message;
-      res.json({ message });
+      res.json({ message, ...(nudge ? { nudge } : {}) });
     }
   } catch (error) {
     next(error);

--- a/src/models/Session.js
+++ b/src/models/Session.js
@@ -48,6 +48,17 @@ const sessionSchema = new Schema(
     draft: {
       type: String,
     },
+    // Background supervisor (instructor-only). Flags raised while observing the
+    // activity; never exposed to the student. supervisorState tracks the
+    // observation cursor and any pending student nudge.
+    supervisorFlags: {
+      type: [Schema.Types.Mixed],
+      default: undefined,
+    },
+    supervisorState: {
+      type: Schema.Types.Mixed,
+      default: undefined,
+    },
   },
   {
     strict: false,

--- a/src/repositories/v1/MessageRepository.js
+++ b/src/repositories/v1/MessageRepository.js
@@ -12,7 +12,9 @@ class MessageRepository {
   }
 
   async findBySession(sessionId) {
-    return await Message.find({ session: sessionId });
+    // Explicit chronological order (don't rely on natural/ObjectId order) —
+    // the supervisor's transcript window and the rendered history both need it.
+    return await Message.find({ session: sessionId }).sort({ timestamp: 1, _id: 1 });
   }
 
   // WRITE METHODS

--- a/src/repositories/v1/SessionRepository.js
+++ b/src/repositories/v1/SessionRepository.js
@@ -98,6 +98,24 @@ class SessionRepository {
   async addMessage(id, messageId) {
     return await Session.findByIdAndUpdate(id, { $push: { messages: messageId } }, { new: true });
   }
+
+  // Append supervisor flags (if any) and advance the observation state in one write.
+  async appendSupervisorObservation(id, flags, supervisorState) {
+    const update = { $set: { supervisorState } };
+    if (Array.isArray(flags) && flags.length > 0) {
+      update.$push = { supervisorFlags: { $each: flags } };
+    }
+    return await Session.findByIdAndUpdate(id, update, { new: true });
+  }
+
+  // Clear a delivered student nudge. When `value` is given, only clear if the
+  // stored nudge still equals it — so a nudge written by an in-flight
+  // observation between capture and clear isn't clobbered (race-safe).
+  async clearPendingNudge(id, value) {
+    const filter = { _id: id };
+    if (typeof value === 'string') filter['supervisorState.pendingNudge'] = value;
+    return await Session.findOneAndUpdate(filter, { $unset: { 'supervisorState.pendingNudge': 1 } }, { new: true });
+  }
 }
 
 export default new SessionRepository();

--- a/src/services/v1/InteractionService.js
+++ b/src/services/v1/InteractionService.js
@@ -4,6 +4,7 @@ import UserService from './UserService.js';
 import MessageService from './MessageService.js';
 import RunnerService from './RunnerService.js';
 import SpectatorService from './SpectatorService.js';
+import SupervisorService from './SupervisorService.js';
 import logger from '../../utils/logger.js';
 import mongoose from 'mongoose';
 
@@ -15,6 +16,17 @@ import mongoose from 'mongoose';
 //
 // Returns the tools unchanged when the problem declares no widgets/tools, so
 // activities without tool functions are unaffected.
+// Strip instructor-only supervisor data from a session before it is returned
+// to the student (any student-facing endpoint that serialises a Session).
+function stripSupervisorFields(session) {
+  const data = session && typeof session.toObject === 'function' ? session.toObject({ virtuals: true }) : { ...session };
+  delete data._id;
+  delete data.__v;
+  delete data.supervisorFlags;
+  delete data.supervisorState;
+  return data;
+}
+
 function applyProblemToolConfig(tools, leia) {
   if (!Array.isArray(tools) || tools.length === 0) return tools;
 
@@ -216,7 +228,12 @@ class InteractionService {
     }
     leia.hideAudioTranscription = hideAudioTranscription;
 
-    return { session, messages, leia, replication };
+    // Supervisor data is instructor-only: strip it (and the supervisor config)
+    // from the payload the student receives.
+    const sessionData = stripSupervisorFields(session);
+    if (leia.leia?.spec) delete leia.leia.spec.supervisorConfig;
+
+    return { session: sessionData, messages, leia, replication };
   }
 
   async getSolutionAndFormat(sessionId) {
@@ -239,7 +256,7 @@ class InteractionService {
       throw error;
     }
 
-    const leia = ReplicationService.findLeia(session.replication, session.leia);
+    const leia = await ReplicationService.findLeia(session.replication, session.leia);
     if (!leia) {
       const error = new Error('Leia not found');
       error.statusCode = 404;
@@ -266,7 +283,7 @@ class InteractionService {
       throw error;
     }
 
-    const leia = ReplicationService.findLeia(session.replication, session.leia);
+    const leia = await ReplicationService.findLeia(session.replication, session.leia);
 
     if (!leia) {
       const error = new Error('Leia not found');
@@ -279,6 +296,10 @@ class InteractionService {
       error.statusCode = 403;
       throw error;
     }
+
+    // A nudge queued by the supervisor on a PREVIOUS turn is delivered on this
+    // turn's response (the student has no socket; this is the reliable channel).
+    const pendingNudge = session.supervisorState?.pendingNudge || null;
 
     const { tools, toolResults } = options;
     const isToolContinuation = Array.isArray(toolResults) && toolResults.length > 0;
@@ -300,6 +321,12 @@ class InteractionService {
     // for older code paths). Only persist a Leia message when we got a
     // final text response back.
     if (runnerResponse && Array.isArray(runnerResponse.toolCalls) && runnerResponse.toolCalls.length > 0) {
+      // A tool round-trip is still the same logical turn; deliver any pending
+      // nudge here too so it isn't dropped for tool-using activities.
+      if (pendingNudge) {
+        await SessionService.clearPendingNudge(session.id, pendingNudge);
+        return { toolCalls: runnerResponse.toolCalls, nudge: pendingNudge };
+      }
       return { toolCalls: runnerResponse.toolCalls };
     }
 
@@ -307,6 +334,18 @@ class InteractionService {
     if (leiaMessage) {
       const newLeiaMessage = await MessageService.create(leiaMessage, true, session.id);
       session = await SessionService.addMessage(session.id, newLeiaMessage.id);
+
+      // A full exchange completed: let the background supervisor observe it
+      // (fire-and-forget; respects cadence and is a no-op when disabled).
+      SupervisorService.observeAsync(session.id, leia);
+    }
+
+    // Deliver (and clear) any nudge the supervisor queued previously. The clear
+    // is conditional on the delivered value so a nudge written by this turn's
+    // in-flight observation isn't clobbered.
+    if (pendingNudge) {
+      await SessionService.clearPendingNudge(session.id, pendingNudge);
+      return { message: leiaMessage, nudge: pendingNudge };
     }
 
     return { message: leiaMessage };
@@ -328,13 +367,17 @@ class InteractionService {
 
     session = await SessionService.saveResultAndFinish(session.id, result);
 
+    // Final supervisor pass (covers the onFinish cadence and the last turns).
+    const finishedLeia = await ReplicationService.findLeia(session.replication, session.leia);
+    if (finishedLeia) SupervisorService.observeAsync(session.id, finishedLeia, { force: true });
+
     // Generate spectator link with 1 year expiration
     const oneYearInSeconds = 365 * 24 * 60 * 60; // 31,536,000 seconds
     const spectatorData = await SpectatorService.generateSpectateToken(session.id, oneYearInSeconds);
     const spectateUrl = SpectatorService.generateSpectateUrl(session.id, spectatorData.token);
 
     return {
-      ...session.toObject(),
+      ...stripSupervisorFields(session),
       spectateUrl,
       spectateToken: spectatorData.token,
       spectateExpiresAt: spectatorData.expiresAt,
@@ -354,6 +397,11 @@ class InteractionService {
       throw error;
     }
     session = await SessionService.finish(session.id);
+
+    // Final supervisor pass (covers the onFinish cadence and the last turns).
+    const finishedLeia = await ReplicationService.findLeia(session.replication, session.leia);
+    if (finishedLeia) SupervisorService.observeAsync(session.id, finishedLeia, { force: true });
+
     await RunnerService.deleteCache(session.id);
     logger.info(`Cache deleted for session ${session.id}`);
 
@@ -363,7 +411,7 @@ class InteractionService {
     const spectateUrl = SpectatorService.generateSpectateUrl(session.id, spectatorData.token);
 
     return {
-      ...session.toObject(),
+      ...stripSupervisorFields(session),
       spectateUrl,
       spectateToken: spectatorData.token,
       spectateExpiresAt: spectatorData.expiresAt,
@@ -382,7 +430,8 @@ class InteractionService {
       error.statusCode = 403;
       throw error;
     }
-    return await SessionService.saveDraft(session.id, draft);
+    const updated = await SessionService.saveDraft(session.id, draft);
+    return stripSupervisorFields(updated);
   }
 
   async getEvaluation(sessionId) {

--- a/src/services/v1/LukeService.js
+++ b/src/services/v1/LukeService.js
@@ -3,6 +3,7 @@ import SessionRepository from '../../repositories/v1/SessionRepository.js';
 import ReplicationService from './ReplicationService.js';
 import MessageService from './MessageService.js';
 import SessionService from './SessionService.js';
+import SupervisorService from './SupervisorService.js';
 import logger from '../../utils/logger.js';
 import jwt from 'jsonwebtoken';
 
@@ -58,6 +59,11 @@ class LukeService {
             const isLeia = transcription.role === 'assistant';
             const message = await MessageService.create(transcription.text, isLeia, userSession.sessionId);
             await SessionService.addMessage(userSession.sessionId, message.id);
+            // Observe luke (audio) exchanges too. Trigger on the LEIA turn; the
+            // supervisor applies its own transcript-window + cadence logic.
+            if (isLeia && userSession.leia) {
+              SupervisorService.observeAsync(userSession.sessionId, userSession.leia);
+            }
           } catch (err) {
             logger.error(`Failed to save luke transcription: ${err.message}`);
           }

--- a/src/services/v1/RunnerService.js
+++ b/src/services/v1/RunnerService.js
@@ -74,6 +74,20 @@ class RunnerService {
     });
     return response.data.models;
   }
+
+  // Stateless supervisor observation. Returns { flags, nudge }.
+  async observeSupervisor({ runnerConfiguration, transcript, supervisorConfig }) {
+    const response = await axios.post(
+      `${process.env.RUNNER_URL}/api/v1/supervisor`,
+      { runnerConfiguration, transcript, supervisorConfig },
+      {
+        headers: {
+          Authorization: 'Bearer ' + process.env.RUNNER_KEY,
+        },
+      }
+    );
+    return response.data;
+  }
 }
 
 

--- a/src/services/v1/SessionService.js
+++ b/src/services/v1/SessionService.js
@@ -113,6 +113,14 @@ class SessionService {
   async saveDraft(id, draft) {
     return await SessionRepository.update(id, { draft });
   }
+
+  async appendSupervisorObservation(id, flags, supervisorState) {
+    return await SessionRepository.appendSupervisorObservation(id, flags, supervisorState);
+  }
+
+  async clearPendingNudge(id, value) {
+    return await SessionRepository.clearPendingNudge(id, value);
+  }
 }
 
 export default new SessionService();

--- a/src/services/v1/SupervisorService.js
+++ b/src/services/v1/SupervisorService.js
@@ -1,0 +1,139 @@
+import SessionService from './SessionService.js';
+import MessageService from './MessageService.js';
+import RunnerService from './RunnerService.js';
+import { emitToReplicationAdmins } from '../../socket/index.js';
+import logger from '../../utils/logger.js';
+
+const DEFAULT_EVERY_N = 4;
+const TRANSCRIPT_WINDOW = 12; // messages of context sent to the supervisor
+
+// Background supervisor: a per-LEIA LLM (configured by the instructor in the
+// designer, at `leia.leia.spec.supervisorConfig`) that observes the activity
+// transcript and raises instructor-only flags, optionally nudging the student.
+//
+// Runs entirely fire-and-forget from the message hooks — it must never block or
+// break a student turn, and never expose anything to the student except an
+// explicit nudge the instructor enabled.
+class SupervisorService {
+  // Fire-and-forget: swallow every error, the activity must not be affected.
+  observeAsync(sessionId, leia, options = {}) {
+    Promise.resolve()
+      .then(() => this.observe(sessionId, leia, options))
+      .catch((err) => {
+        logger.error(`Supervisor observation failed for session ${sessionId}: ${err.message}`);
+      });
+  }
+
+  async observe(sessionId, leia, options = {}) {
+    const supervisorConfig = leia?.leia?.spec?.supervisorConfig;
+    if (!supervisorConfig || supervisorConfig.enabled !== true) return;
+
+    // BYOK: the supervisor ALWAYS runs on OpenAI, independent of the LEIA's own
+    // provider. Prefer its dedicated OpenAI key (chosen in the designer); fall
+    // back to the LEIA's runner key only when that key is itself OpenAI.
+    const runnerConfiguration = leia.runnerConfiguration || {};
+    const apiKeyId = supervisorConfig.apiKeyId || runnerConfiguration.apiKeyId;
+    const apiKeyRequesterId = supervisorConfig.apiKeyRequesterId || runnerConfiguration.apiKeyRequesterId;
+    if (!apiKeyId || !apiKeyRequesterId) {
+      logger.warn(`Supervisor enabled but no OpenAI BYOK key for session ${sessionId}; skipping.`);
+      return;
+    }
+
+    const session = await SessionService.findById(sessionId);
+    if (!session) return;
+
+    const messages = await MessageService.findBySession(sessionId);
+    const totalCount = messages.length;
+    if (totalCount === 0) return;
+
+    const state = session.supervisorState || {};
+    const lastObserved = Number.isInteger(state.lastObservedCount) ? state.lastObservedCount : 0;
+
+    // Nothing new since the last pass — skip even when forced (e.g. on finish).
+    if (totalCount === lastObserved) return;
+
+    const cadence = supervisorConfig.cadence === 'onFinish' ? 'onFinish' : 'everyN';
+    const everyN =
+      Number.isInteger(supervisorConfig.everyN) && supervisorConfig.everyN > 0
+        ? supervisorConfig.everyN
+        : DEFAULT_EVERY_N;
+
+    // `force` (session finish) bypasses the cadence gate for a final pass.
+    if (!options.force) {
+      if (cadence === 'onFinish') return; // only observe at the end
+      // Always run the FIRST pass once there's something to look at; afterwards
+      // respect the cadence. This way short sessions still get observed and the
+      // gate doesn't silently skip the opening exchanges.
+      if (lastObserved > 0 && totalCount - lastObserved < everyN) return;
+    }
+
+    const window = messages.slice(-TRANSCRIPT_WINDOW).map((m) => ({
+      role: m.isLeia ? 'leia' : 'student',
+      text: m.text,
+    }));
+
+    const result = await RunnerService.observeSupervisor({
+      // BYOK identity only. The supervisor ALWAYS runs on OpenAI, so we must not
+      // pass the LEIA's modelName here — it may be a non-OpenAI model (gemini,
+      // ollama). The supervisor model comes from supervisorConfig.model (else a
+      // default OpenAI model on the runner).
+      runnerConfiguration: {
+        apiKeyId,
+        apiKeyRequesterId,
+      },
+      transcript: window,
+      supervisorConfig: {
+        instructions: supervisorConfig.instructions,
+        categories: supervisorConfig.categories,
+        sensitivity: supervisorConfig.sensitivity,
+        intervene: supervisorConfig.intervene,
+        interveneInstructions: supervisorConfig.interveneInstructions,
+        model: supervisorConfig.model,
+      },
+    });
+
+    const rawFlags = Array.isArray(result?.flags) ? result.flags : [];
+    const now = new Date();
+    const stampedFlags = rawFlags.map((f) => ({
+      category: typeof f.category === 'string' ? f.category : 'observation',
+      severity: ['low', 'medium', 'high'].includes(f.severity) ? f.severity : 'low',
+      note: typeof f.note === 'string' ? f.note : '',
+      quote: typeof f.quote === 'string' && f.quote.trim() ? f.quote : null,
+      at: now,
+    }));
+
+    // The nudge is only honoured when intervention is enabled and the session
+    // is still live (a finished student can't receive it).
+    const nudge =
+      supervisorConfig.intervene && !session.finishedAt && typeof result?.nudge === 'string' && result.nudge.trim()
+        ? result.nudge.trim()
+        : null;
+
+    const newState = {
+      ...state,
+      lastObservedCount: totalCount,
+      lastObservedAt: now,
+    };
+    if (nudge) newState.pendingNudge = nudge;
+
+    await SessionService.appendSupervisorObservation(sessionId, stampedFlags, newState);
+
+    // Surface to the instructor live — ADMIN sockets in the dashboard room only,
+    // never the student and never share-token dashboard viewers. The nudge is
+    // delivered to the student via the HTTP turn response, not over this channel.
+    if (stampedFlags.length > 0) {
+      try {
+        const totalFlags = (Array.isArray(session.supervisorFlags) ? session.supervisorFlags.length : 0) + stampedFlags.length;
+        emitToReplicationAdmins(session.replication.toString(), 'session:supervisorFlag', {
+          sessionId,
+          flags: stampedFlags,
+          flagCount: totalFlags,
+        });
+      } catch (err) {
+        logger.error(`Failed to emit supervisor flag for session ${sessionId}: ${err.message}`);
+      }
+    }
+  }
+}
+
+export default new SupervisorService();

--- a/src/socket/index.js
+++ b/src/socket/index.js
@@ -176,6 +176,24 @@ export function emitToReplication(replicationId, event, data) {
   io.to(`replication:${replicationId}`).emit(event, data);
 }
 
+// Like emitToReplication but only to ADMIN sockets in the room. Used for
+// instructor-only data (e.g. supervisor flags) that share-token dashboard
+// viewers must not receive.
+export function emitToReplicationAdmins(replicationId, event, data) {
+  if (!io) {
+    logger.warn('Socket.IO not initialized, cannot emit event');
+    return;
+  }
+  const room = io.sockets.adapter.rooms.get(`replication:${replicationId}`);
+  if (!room) return;
+  for (const socketId of room) {
+    const socket = io.sockets.sockets.get(socketId);
+    if (socket?.user?.isAdmin) {
+      socket.emit(event, data);
+    }
+  }
+}
+
 export function getIO() {
   if (!io) {
     throw new Error('Socket.IO not initialized');


### PR DESCRIPTION
Observes text and Luke activity (fire-and-forget) on a per-N-messages cadence, stores instructor-only supervisorFlags, emits them to admin dashboard sockets only, and delivers an optional coaching nudge to the student on the next turn. Strips supervisor data from student-facing payloads. Also awaits the previously-unawaited ReplicationService.findLeia and sorts messages chronologically.