### PR TITLE
Feature/infographics

### DIFF
--- a/src/services/v1/InteractionService.js
+++ b/src/services/v1/InteractionService.js
@@ -59,6 +59,12 @@ function applyProblemToolConfig(tools, leia) {
   return out;
 }
 
+function buildLeiaInfographicFallbackPaths(leiaId) {
+  const id = leiaId ? `${leiaId}`.trim() : '';
+  if (!id) return [];
+  return ['png', 'jpg'].map((extension) => `/images/leias/${id}/infographic/original.${extension}`);
+}
+
 class InteractionService {
   async startSession(userEmail, replicationCode) {
     logger.info(`User ${userEmail} is trying to join replication ${replicationCode}`);
@@ -195,6 +201,14 @@ class InteractionService {
     const runnerLukeConfig = leia.runnerConfiguration?.lukeConfig || null;
     const runnerProvider = leia.runnerConfiguration?.provider || null;
     const hideAudioTranscription = leia.runnerConfiguration?.hideAudioTranscription || null;
+    const infographicConfig = leia.runnerConfiguration?.infographic || {};
+    const infographicSrc = leia.leia?.spec?.infographic || null;
+    const infographicFallbackSources = buildLeiaInfographicFallbackPaths(leia.leia?.id || leia.leia?._id || leia.id);
+    const infographicFallbackSrc = infographicFallbackSources[0] || null;
+    if (leia.leia?.spec) {
+      delete leia.leia.spec.infographic;
+      delete leia.leia.spec.infographicSolution;
+    }
 
     // Widgets now live in the problem definition (authored in the designer)
     // and ride here inside leia.leia.spec.problem.spec.widgets. Fall back to
@@ -220,6 +234,13 @@ class InteractionService {
       (audioMode == null && runnerProvider === 'openai-responses');
 
     leia.audioMode = audioMode;
+    if (infographicConfig.showToStudent && (infographicSrc || infographicFallbackSrc)) {
+      leia.infographic = {
+        src: infographicSrc || infographicFallbackSrc,
+        fallbackSrc: infographicFallbackSrc,
+        fallbackSources: infographicFallbackSources,
+      };
+    }
     // Expose the widgets (+ luke provider/voice when present) to the FE under
     // `lukeConfig` — the shape Chat.tsx already consumes — whenever the active
     // mode can actually use them. The mode itself stays a workbench concern.

--- a/src/utils/entity.js
+++ b/src/utils/entity.js
@@ -39,6 +39,9 @@ export function initializeExperiment(experiment) {
       modelName: 'default',
       audioMode: null,
       hideAudioTranscription: null,
+      infographic: {
+        showToStudent: false,
+      },
     };
     leia.sessionCount = 0;
     leia.configuration.askSolution = true;

--- a/src/validators/v1/replicationValidator.js
+++ b/src/validators/v1/replicationValidator.js
@@ -32,6 +32,7 @@ export const updateReplicationLeiaRunnerConfigurationValidator = Joi.object({
   }),
   infographic: Joi.object({
     showToStudent: Joi.boolean().optional().default(false),
+    allowDownload: Joi.any().strip(),
   }).optional(),
   lukeConfig: Joi.object({
     // provider/voice are only meaningful when audioMode === 'luke'. The

--- a/src/validators/v1/replicationValidator.js
+++ b/src/validators/v1/replicationValidator.js
@@ -30,6 +30,9 @@ export const updateReplicationLeiaRunnerConfigurationValidator = Joi.object({
     then: Joi.boolean().optional().default(false),
     otherwise: Joi.valid(null).optional().default(null),
   }),
+  infographic: Joi.object({
+    showToStudent: Joi.boolean().optional().default(false),
+  }).optional(),
   lukeConfig: Joi.object({
     // provider/voice are only meaningful when audioMode === 'luke'. The
     // same lukeConfig bucket is reused by text mode (which only needs


### PR DESCRIPTION
- Adds replication configuration support for showing LEIA infographics to students.
- Exposes student-facing infographic metadata in interaction payloads when enabled.
- Adds fallback infographic paths for LEIA resources.
- Keeps solution infographics and supervisor/internal fields out of student-facing payloads.
- Persists infographic visibility settings in replication runner configuration.