### PR TITLE
feat: validate environment-scoped Auth tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,8 @@ NODE_ENV=develop
 AUTH_URL=http://localhost:3005
 OPENAI_API_KEY=sk-proj-...
 JWT_SECRET=secret
+JWT_ISSUER=http://localhost:3005
+JWT_AUDIENCE=leia-platform
 
 # RUNNER CONFIGURATION
 RUNNER_URL=http://localhost:5002

--- a/src/utils/jwt.js
+++ b/src/utils/jwt.js
@@ -1,5 +1,12 @@
 import jwt from 'jsonwebtoken';
 
 export function verifyToken(token) {
-  return jwt.verify(token, process.env.JWT_SECRET);
+  const payload = jwt.verify(token, process.env.JWT_SECRET, {
+    ...(process.env.JWT_ISSUER ? { issuer: process.env.JWT_ISSUER } : {}),
+    ...(process.env.JWT_AUDIENCE ? { audience: process.env.JWT_AUDIENCE } : {}),
+  });
+  if (payload.type && payload.type !== 'access') {
+    throw new Error('Access token required');
+  }
+  return payload;
 }

--- a/tests/jwt.test.js
+++ b/tests/jwt.test.js
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import jwt from 'jsonwebtoken';
+import { verifyToken } from '../src/utils/jwt.js';
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  process.env.JWT_SECRET = 'test-secret';
+  process.env.JWT_ISSUER = 'https://pre.auth.leia.ovh';
+  process.env.JWT_AUDIENCE = 'leia-platform';
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+});
+
+const sign = (payload, options = {}) => jwt.sign(payload, process.env.JWT_SECRET, {
+  issuer: process.env.JWT_ISSUER,
+  audience: process.env.JWT_AUDIENCE,
+  expiresIn: '15m',
+  ...options,
+});
+
+describe('Auth access JWT verification', () => {
+  test('accepts an access token from the configured Auth environment', () => {
+    expect(verifyToken(sign({ id: 'user-1', role: 'admin', type: 'access' }))).toMatchObject({
+      id: 'user-1',
+      role: 'admin',
+      type: 'access',
+    });
+  });
+
+  test('keeps accepting issuer-bound legacy tokens during rollout', () => {
+    expect(verifyToken(sign({ id: 'user-1', role: 'admin' }))).toMatchObject({ id: 'user-1' });
+  });
+
+  test('rejects session tokens and tokens issued for another environment', () => {
+    expect(() => verifyToken(sign({ id: 'user-1', type: 'session' }))).toThrow('Access token required');
+    const productionToken = sign(
+      { id: 'user-1', type: 'access' },
+      { issuer: 'https://auth.leia.ovh' },
+    );
+    expect(() => verifyToken(productionToken)).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- validate Auth JWT issuer and audience when configured
- accept access and rollout-compatible legacy tokens
- reject central session tokens at the Workbench API boundary
- document local issuer and audience configuration

## Rollout
Deploy after or together with leia-auth and before the Workbench frontend SSO client.

## Validation
- 11 tests pass
- ESLint passes